### PR TITLE
Resolve wrong cursor position used when using a touchscreen

### DIFF
--- a/colorwheel.cpp
+++ b/colorwheel.cpp
@@ -144,10 +144,11 @@ bool ColorWheel::isHitMode() noexcept {
 QColor ColorWheel::hueAt( const QVector2D in_mouseVec ) noexcept {
 
     const QVector2D vec { 1.0, 0.0 };
+
     qreal angle = qRadiansToDegrees( std::acos( QVector2D::dotProduct( vec, in_mouseVec ) / ( in_mouseVec.length() * vec.length() ) ) );
 
     m_quadHit
-        = getQuadrant( QPoint( static_cast<int>( mapFromGlobal( QCursor::pos() ).x() ), static_cast<int>( mapFromGlobal( QCursor::pos() ).y() ) ) );
+        = getQuadrant( QPoint( static_cast<int>( mapFromGlobal( m_mouseGlobalPos ).x() ), static_cast<int>( mapFromGlobal( m_mouseGlobalPos ).y() ) ) );
 
     if ( m_quadHit == UpDown::DOWN ) {
         angle = ONETURN - angle;
@@ -185,6 +186,10 @@ void ColorWheel::updateMousePosition( const QPoint position ) {
     m_mouseVec = QVector2D( static_cast<float>( position.x() - width() / 2.0F ), static_cast<float>( position.y() - height() / 2.0F ) );
 }
 
+void ColorWheel::updateMouseGlobalPosition( const QPointF position ) {
+    m_mouseGlobalPos = position;
+}
+
 // *****************************
 // PROTECTED
 // *****************************
@@ -196,6 +201,7 @@ void ColorWheel::mousePressEvent( QMouseEvent* event ) {
     }
 
     updateMousePosition( event->pos() );
+    updateMouseGlobalPosition( event->globalPosition() );
 
     if ( !isHitMode() ) {
         return;
@@ -226,6 +232,7 @@ void ColorWheel::mouseMoveEvent( QMouseEvent* event ) {
     }
 
     updateMousePosition( event->pos() );
+    updateMouseGlobalPosition( event->globalPosition() );
 
     switch ( m_hitMode ) {
         case HitPosition::WHEEL:

--- a/colorwheel.h
+++ b/colorwheel.h
@@ -37,6 +37,7 @@ private:
     QPolygonF m_arrow;
 
     QVector2D m_mouseVec;
+    QPointF m_mouseGlobalPos;
     qreal m_outerRadius;
     qreal m_innerRadius;
     qreal m_indicatorSize;
@@ -48,6 +49,7 @@ private:
     [[nodiscard]] UpDown getQuadrant( QPoint position ) noexcept;
 
     void updateMousePosition( QPoint position );
+    void updateMouseGlobalPosition( QPointF position );
 
 protected:
     void mousePressEvent( QMouseEvent* event ) override;


### PR DESCRIPTION
When using a touchscreen, the cursor::pos() is invalid.

Using the current event global position instead.
